### PR TITLE
Convert EventArgsCacheGenerator to C# 7.3 compatible syntax

### DIFF
--- a/src/PropertyChanged.SourceGenerator.UnitTests/AlsoNotifyTests.HandlesStandardNonPropertyNames_PropertyChanged.SourceGenerator.Internal.EventArgsCache.verified.cs
+++ b/src/PropertyChanged.SourceGenerator.UnitTests/AlsoNotifyTests.HandlesStandardNonPropertyNames_PropertyChanged.SourceGenerator.Internal.EventArgsCache.verified.cs
@@ -3,12 +3,12 @@
     internal static class EventArgsCache
     {
         private static global::System.ComponentModel.PropertyChangedEventArgs _PropertyChanged_Null;
-        public static global::System.ComponentModel.PropertyChangedEventArgs PropertyChanged_Null => _PropertyChanged_Null ??= new global::System.ComponentModel.PropertyChangedEventArgs(null);
+        public static global::System.ComponentModel.PropertyChangedEventArgs PropertyChanged_Null => _PropertyChanged_Null = _PropertyChanged_Null ?? new global::System.ComponentModel.PropertyChangedEventArgs(null);
         private static global::System.ComponentModel.PropertyChangedEventArgs _PropertyChanged_Empty;
-        public static global::System.ComponentModel.PropertyChangedEventArgs PropertyChanged_Empty => _PropertyChanged_Empty ??= new global::System.ComponentModel.PropertyChangedEventArgs(@"");
+        public static global::System.ComponentModel.PropertyChangedEventArgs PropertyChanged_Empty => _PropertyChanged_Empty = _PropertyChanged_Empty ?? new global::System.ComponentModel.PropertyChangedEventArgs(@"");
         private static global::System.ComponentModel.PropertyChangedEventArgs _PropertyChanged_Foo;
-        public static global::System.ComponentModel.PropertyChangedEventArgs PropertyChanged_Foo => _PropertyChanged_Foo ??= new global::System.ComponentModel.PropertyChangedEventArgs(@"Foo");
+        public static global::System.ComponentModel.PropertyChangedEventArgs PropertyChanged_Foo => _PropertyChanged_Foo = _PropertyChanged_Foo ?? new global::System.ComponentModel.PropertyChangedEventArgs(@"Foo");
         private static global::System.ComponentModel.PropertyChangedEventArgs _PropertyChanged_Item;
-        public static global::System.ComponentModel.PropertyChangedEventArgs PropertyChanged_Item => _PropertyChanged_Item ??= new global::System.ComponentModel.PropertyChangedEventArgs(@"Item[]");
+        public static global::System.ComponentModel.PropertyChangedEventArgs PropertyChanged_Item => _PropertyChanged_Item = _PropertyChanged_Item ?? new global::System.ComponentModel.PropertyChangedEventArgs(@"Item[]");
     }
 }

--- a/src/PropertyChanged.SourceGenerator/EventArgsCacheGenerator.cs
+++ b/src/PropertyChanged.SourceGenerator/EventArgsCacheGenerator.cs
@@ -39,7 +39,7 @@ public class EventArgsCacheGenerator
             }
             this.writer.WriteLine($"private static {eventArgsTypeName} {backingFieldName};");
             this.writer.WriteLine($"public static {eventArgsTypeName} {cacheName} => " +
-                $"{backingFieldName} ??= new {eventArgsTypeName}({EscapeString(propertyName)});");
+                $"{backingFieldName} = {backingFieldName} ?? new {eventArgsTypeName}({EscapeString(propertyName)});");
         }
 
         this.writer.Indent--;


### PR DESCRIPTION
- EventArgsCacheGenerator currently generates code which requires C# 8.0 (.NET Core).
- This results in generated code not compiling when targeting C# 7.3 (.NET Framework 4.8).
- This PR updates the syntax to be compatible with C# 7.3 for generated code.