### PR TITLE
Fix for #50

### DIFF
--- a/src/PropertyChanged.SourceGenerator.UnitTests/RaisePropertyChangedCallTests.FindsAndCallsMethodWithStringNameEvenWithUnrecognisableOverload_Derived.verified.cs
+++ b/src/PropertyChanged.SourceGenerator.UnitTests/RaisePropertyChangedCallTests.FindsAndCallsMethodWithStringNameEvenWithUnrecognisableOverload_Derived.verified.cs
@@ -1,0 +1,15 @@
+﻿partial class Derived
+{
+    public string Foo
+    {
+        get => this._foo;
+        set
+        {
+            if (!global::System.Collections.Generic.EqualityComparer<string>.Default.Equals(value, this._foo))
+            {
+                this._foo = value;
+                this.OnPropertyChanged(@"Foo");
+            }
+        }
+    }
+}

--- a/src/PropertyChanged.SourceGenerator.UnitTests/RaisePropertyChangedCallTests.cs
+++ b/src/PropertyChanged.SourceGenerator.UnitTests/RaisePropertyChangedCallTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using NUnit.Framework;
 using PropertyChanged.SourceGenerator.UnitTests.Framework;
@@ -144,6 +139,28 @@ public class RaisePropertyChangedCallTests : TestsBase
             """;
 
         this.AssertThat(input, It.HasFile("SomeViewModel"));
+    }
+
+    [Test]
+    public void FindsAndCallsMethodWithStringNameEvenWithUnrecognisableOverload()
+    {
+        string input = """
+           using System.ComponentModel;
+           public class Base : INotifyPropertyChanged
+           {
+               public event PropertyChangedEventHandler PropertyChanged;
+               protected virtual void OnPropertyChanged(string name) =>
+                   PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+               protected virtual void OnPropertyChanged(int arg) { }
+           }
+           public partial class Derived : Base
+           {
+               [Notify]
+               private string _foo;
+           }
+           """;
+
+        this.AssertThat(input, It.HasFile("Derived"));
     }
 
     [Test]

--- a/src/PropertyChanged.SourceGenerator/Analysis/InterfaceAnalyser.cs
+++ b/src/PropertyChanged.SourceGenerator/Analysis/InterfaceAnalyser.cs
@@ -72,7 +72,7 @@ public abstract class InterfaceAnalyser
         //   a. If PropertyChanged is in a base class, we'll need to abort if we can't find one
         //   b. If PropertyChanged is in our class, we'll just define one and call it
 
-        
+
         IEventSymbol? eventSymbol = null;
 
         bool updateTypeToInterfaceEventCache = false;
@@ -291,7 +291,7 @@ public abstract class InterfaceAnalyser
 
         // The most common case is that the type inherits from one that we already know about and which has the same config as us, and doesn't
         // add any new members that we care about, so optimise for this case.
-        if (typeSymbol.BaseType != null && 
+        if (typeSymbol.BaseType != null &&
             this.discoveredMethodInfoCache.TryGetValue(new DiscoveredMethodInfoKey(typeSymbol.BaseType, methodNamesEquatableArray), out var discoveredCachedMethodInfo) &&
             !typeSymbol.GetMembers().Any(x => x is IMethodSymbol { IsStatic: false } && methodNamesLookup.Contains(x.Name)))
         {
@@ -350,6 +350,8 @@ public abstract class InterfaceAnalyser
         {
             foreach (string methodName in methodNames)
             {
+                bool foundMethodWithThisName = false;
+
                 if (methodName == discoveredBaseMethodInfo?.Method?.Name && RaisePropertyChangedOrChangingMethodSignatureBetternessComparer.Instance.Compare(discoveredBaseMethodInfo?.Signature, discoveredMethodInfo?.Signature) > 0)
                 {
                     discoveredMethodInfo = discoveredBaseMethodInfo;
@@ -366,6 +368,7 @@ public abstract class InterfaceAnalyser
                             if (RaisePropertyChangedOrChangingMethodSignatureBetternessComparer.Instance.Compare(signature, discoveredMethodInfo?.Signature) > 0)
                             {
                                 discoveredMethodInfo = new(discoveredMethod, signature, methodNamesFoundButDidntKnowHowToCall);
+                                foundMethodWithThisName = true;
                             }
                         }
                         else
@@ -373,12 +376,14 @@ public abstract class InterfaceAnalyser
                             if (discoveredMethod.ContainingType.AllInterfaces.Contains(this.interfaceSymbol, SymbolEqualityComparer.Default))
                             {
                                 methodNamesFoundButDidntKnowHowToCall = methodNamesFoundButDidntKnowHowToCall.Add(methodName);
-                                discoveredMethodInfo = new(null, null, methodNamesFoundButDidntKnowHowToCall);
+                                // Don't set discoveredMethodInfo here, to avoid interfering with identifying valid methodInfos above.
+                                // (We'll set it below if no valid methods are found).
+                                foundMethodWithThisName = true;
                             }
                         }
                     }
 
-                    if (discoveredMethodInfo != null)
+                    if (foundMethodWithThisName)
                     {
                         // We found something for this method name. Stop now.
                         break;


### PR DESCRIPTION
This is a proposed fix for the issue where a `OnPropertyChanged` method with a 'compatible' signature also has an overload with an 'incompatible' signature. As currently implemented `DiscoverMethods` fails to use the method with the compatible signature.

See also the comments in the added unit test.